### PR TITLE
Prevent insufficient data after filtering in _create_train_code_pred_…

### DIFF
--- a/absolute_zero_reasoner/trainer/ppo/azr_ray_trainer.py
+++ b/absolute_zero_reasoner/trainer/ppo/azr_ray_trainer.py
@@ -707,6 +707,9 @@ class CodeIORayPPOTrainer(ReasonRLRayPPOTrainer):
         ))
 
     def _create_train_code_pred_dataloader(self, problem_type: str, data_len: int) -> DataLoader:
+        
+        data_len = data_len * 2 - 1  # Prevent insufficient data after filtering
+
         if problem_type == 'code_i':
             dataset_key = 'input'
         elif problem_type == 'code_o':


### PR DESCRIPTION
A prevention-based fix was applied by expanding the original data_len request to tolerate minor filtering:

data_len = data_len * 2 - 1 # Prevent insufficient data after filtering
This simple heuristic ensures that even with moderate filtering, the final dataset length is still ≥ train_batch_size.