### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/evaluation/code_eval/coding/LiveCodeBench/lcb_runner/lm_styles.py
+++ b/evaluation/code_eval/coding/LiveCodeBench/lcb_runner/lm_styles.py
@@ -287,6 +287,14 @@ LanguageModelList: list[LanguageModel] = [
         datetime(2023, 4, 30),
         link="https://openai.com/index/spring-update",
     ),
+    ## Forge (OpenAI-compatible)
+    LanguageModel(
+        "OpenAI/gpt-4o-mini",
+        "Forge-OpenAI-GPT-4o-mini",
+        LMStyle.OpenAIChat,
+        datetime(2024, 7, 18),
+        link="https://forge.tensorblock.co",
+    ),
     ## O1-Mini and O1-Preview
     LanguageModel(
         "o1-preview-2024-09-12",

--- a/evaluation/code_eval/coding/LiveCodeBench/lcb_runner/runner/oai_runner.py
+++ b/evaluation/code_eval/coding/LiveCodeBench/lcb_runner/runner/oai_runner.py
@@ -12,12 +12,20 @@ from lcb_runner.runner.base_runner import BaseRunner
 
 
 class OpenAIRunner(BaseRunner):
-    client = OpenAI(
-        api_key=os.getenv("OPENAI_KEY"),
-    )
+    @staticmethod
+    def _build_client():
+        forge_api_key = os.getenv("FORGE_API_KEY")
+        if forge_api_key:
+            return OpenAI(
+                api_key=forge_api_key,
+                base_url=os.getenv("FORGE_API_BASE")
+                or "https://api.forge.tensorblock.co/v1",
+            )
+        return OpenAI(api_key=os.getenv("OPENAI_KEY"))
 
     def __init__(self, args, model):
         super().__init__(args, model)
+        self.client = self._build_client()
         if model.model_style == LMStyle.OpenAIReasonPreview:
             self.client_kwargs: dict[str | str] = {
                 "model": args.model,
@@ -49,7 +57,7 @@ class OpenAIRunner(BaseRunner):
         assert isinstance(prompt, list)
 
         try:
-            response = OpenAIRunner.client.chat.completions.create(
+            response = self.client.chat.completions.create(
                 messages=prompt,
                 **self.client_kwargs,
             )


### PR DESCRIPTION
## Summary

Adds Forge as an OpenAI-compatible provider to LiveCodeBench runner. When `FORGE_API_KEY` is set, `OpenAIRunner` routes requests through Forge's API instead of OpenAI directly.

## Changes

- `evaluation/code_eval/coding/LiveCodeBench/lcb_runner/lm_styles.py`: Added `LanguageModel` entry for Forge with `LMStyle.OpenAIChat`
- `evaluation/code_eval/coding/LiveCodeBench/lcb_runner/runner/oai_runner.py`: Refactored client initialization from class-level to instance-level `_build_client()` method that selects Forge or OpenAI based on env vars

## Usage

```bash
export FORGE_API_KEY=your-key
# Optional: export FORGE_API_BASE=https://api.forge.tensorblock.co/v1
python -m lcb_runner.runner.main --model OpenAI/gpt-4o-mini
```

## Tests

1 commit, 2 files changed. Existing behavior preserved when `FORGE_API_KEY` is not set.

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/forge) is an open-source middleware service for unified AI model provider management. It routes requests across 40+ AI providers with access to thousands of models through a single OpenAI-compatible API.

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview